### PR TITLE
web: scaffold pages + delete form (phase 1)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings" defaultProject="true" />
+</project>

--- a/404.html
+++ b/404.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Not found – McHub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<main class="container hero">
+    <h1>404</h1>
+    <p class="muted">That page doesn’t exist. <a href="/">Go home</a>.</p>
+</main>
+</body></html>

--- a/about.html
+++ b/about.html
@@ -1,0 +1,23 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>About – McHub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<!-- header/nav (same as index) -->
+<div class="nav"><div class="container"><a class="brand" href="/">McHub</a><nav>
+    <a href="/" data-path="/">Home</a><a href="/about.html" data-path="/about.html">About</a>
+    <a href="/store.html" data-path="/store.html">App Store</a>
+    <a href="/privacy.html" data-path="/privacy.html">User Policy</a>
+    <a href="/delete/" data-path="/delete">Delete Account</a>
+</nav></div></div>
+
+<main class="container">
+    <h1>About McHub</h1>
+    <p>McHub connects Myanmar communities with nearby services, booking, and a curated places directory.</p>
+</main>
+
+<!-- footer -->
+<div class="footer"><div class="container"><p class="muted">© <span id="y"></span> McHub.</p>
+    <script>document.getElementById('y').textContent=new Date().getFullYear();</script></div></div>
+<script src="/assets/js/site.js"></script>
+</body></html>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,24 @@
+:root { --fg:#111; --bg:#fff; --muted:#6b7280; --brand:#2563eb; }
+*{box-sizing:border-box} html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:16px/1.55 system-ui,Segoe UI,Roboto,Arial}
+a{color:var(--brand);text-decoration:none}
+.container{max-width:980px;margin:0 auto;padding:24px}
+.nav{border-bottom:1px solid #eee;background:#fff;position:sticky;top:0}
+.nav .container{display:flex;align-items:center;gap:20px}
+.brand{font-weight:700}
+.nav a{padding:14px 8px;display:inline-block;color:#111}
+.nav a.active{color:var(--brand)}
+.hero{padding:64px 0}
+.hero h1{margin:0 0 8px}
+.muted{color:var(--muted)}
+.footer{border-top:1px solid #eee;margin-top:48px}
+.btn{display:inline-block;padding:10px 14px;border:1px solid var(--brand);border-radius:10px}
+.btn.primary{background:var(--brand);color:#fff}
+.card{border:1px solid #eee;border-radius:14px;padding:18px}
+form label{display:block;margin:14px 0 6px}
+input[type=text],input[type=tel],input[type=email],textarea{
+  width:100%;padding:10px;border:1px solid #ddd;border-radius:10px
+}
+input[type=checkbox]{transform:scale(1.1);margin-right:8px}
+.notice{padding:12px;border-radius:10px;margin-top:12px}
+.notice.ok{background:#ecfdf5;border:1px solid #10b981}
+.notice.err{background:#fef2f2;border:1px solid #ef4444}

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,0 +1,40 @@
+// Simple helper to set active nav link
+(function () {
+  const path = location.pathname.replace(/\/$/, '');
+  document.querySelectorAll('nav a[data-path]').forEach(a => {
+    const p = a.getAttribute('data-path');
+    if (p === path || (p === '/' && (path === '' || path === '/index.html'))) {
+      a.classList.add('active');
+    }
+  });
+})();
+
+// Delete form submit (Phase 1 -> Cloud Function endpoint)
+// Replace YOUR_FIREBASE_PROJECT_ID below before going live.
+async function submitDeleteRequest(e) {
+  e.preventDefault();
+  const form = e.target;
+  const data = Object.fromEntries(new FormData(form).entries());
+  const endpoint =
+    'https://asia-southeast1-YOUR_FIREBASE_PROJECT_ID.cloudfunctions.net/webDeleteRequest';
+
+  const okBox = document.getElementById('okBox');
+  const errBox = document.getElementById('errBox');
+  okBox.textContent = ''; okBox.className = 'notice ok'; okBox.style.display = 'none';
+  errBox.textContent = ''; errBox.className = 'notice err'; errBox.style.display = 'none';
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (!res.ok) throw new Error('Request failed');
+    okBox.textContent = 'Request received. We\'ll process deletion shortly.';
+    okBox.style.display = 'block';
+    form.reset();
+  } catch (err) {
+    errBox.textContent = 'Could not send request. Please try again later.';
+    errBox.style.display = 'block';
+  }
+}

--- a/delete/index.html
+++ b/delete/index.html
@@ -1,0 +1,48 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Delete Account – McHub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<div class="nav"><div class="container"><a class="brand" href="/">McHub</a><nav>
+    <a href="/" data-path="/">Home</a><a href="/about.html" data-path="/about.html">About</a>
+    <a href="/store.html" data-path="/store.html">App Store</a>
+    <a href="/privacy.html" data-path="/privacy.html">User Policy</a>
+    <a href="/delete/" data-path="/delete">Delete Account</a>
+</nav></div></div>
+
+<main class="container">
+    <h1>Request Account Deletion</h1>
+    <p class="muted">If you signed up with phone/Facebook in the app, you can also delete from inside the app. This web form creates a deletion ticket for our team.</p>
+
+    <form id="delForm">
+        <label>Full name</label>
+        <input type="text" name="name" required>
+
+        <label>Phone number (used in app)</label>
+        <input type="tel" name="phone" required>
+
+        <label>App UID (optional)</label>
+        <input type="text" name="uid" placeholder="If known">
+
+        <label>Email (optional)</label>
+        <input type="email" name="email" placeholder="For status update">
+
+        <label>Reason (optional)</label>
+        <textarea name="reason" rows="4" placeholder="Tell us anything we should know"></textarea>
+
+        <label><input type="checkbox" name="confirm" required> I confirm I want my McHub account deleted.</label>
+
+        <p><button class="btn primary" type="submit">Submit deletion request</button></p>
+
+        <div id="okBox" class="notice ok" style="display:none"></div>
+        <div id="errBox" class="notice err" style="display:none"></div>
+    </form>
+</main>
+
+<div class="footer"><div class="container"><p class="muted">© <span id="y"></span> McHub.</p>
+    <script>document.getElementById('y').textContent=new Date().getFullYear();</script></div></div>
+<script src="/assets/js/site.js"></script>
+<script>
+    document.getElementById('delForm').addEventListener('submit', submitDeleteRequest);
+</script>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -1,77 +1,33 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>McHub – Myanmar Community Hub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<!-- header -->
+<div class="nav"><div class="container">
+    <a class="brand" href="/">McHub</a>
+    <nav>
+        <a href="/" data-path="/">Home</a>
+        <a href="/about.html" data-path="/about.html">About</a>
+        <a href="/store.html" data-path="/store.html">App Store</a>
+        <a href="/privacy.html" data-path="/privacy.html">User Policy</a>
+        <a href="/delete/" data-path="/delete">Delete Account</a>
+    </nav>
+</div></div>
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>McHub - Myanmar Community Hub</title>
-    <style>
-        body {
-            font-family: sans-serif;
-            line-height: 1.6;
-            padding: 2rem;
-            background: #f7f7f7;
-            color: #333;
-        }
-        .container {
-            max-width: 800px;
-            margin: auto;
-            background: white;
-            padding: 2rem;
-            border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-        }
-        h1, h2 {
-            color: #145da0;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>Privacy Policy for McHub</h1>
-        <p><strong>Effective Date:</strong> 20 July 2025</p>
-        <h2>Introduction</h2>
-        <p>McHub ("we", "us", or "our") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you use our mobile application.</p>
-        
-        <h2>Information We Collect</h2>
-        <ul>
-            <li>Name (from Facebook or other login)</li>
-            <li>Profile Photo (from Facebook or other login)</li>
-            <li>Email Address (from Facebook or other login)</li>
-            <li>Phone Number (if you set it as public in your profile)</li>
-            <li>Device Location (with your consent, for nearby user features)</li>
-        </ul>
+<main class="container hero">
+    <h1>Myanmar Community Hub</h1>
+    <p class="muted">Services & booking • Nearby places • Community features</p>
+    <p>
+        <a class="btn primary" href="/store.html">Get the App</a>
+        <a class="btn" href="/privacy.html">Read User Policy</a>
+    </p>
+</main>
 
-        <h2>How We Use Your Information</h2>
-        <ul>
-            <li>Provide and personalize your app experience</li>
-            <li>Enable login and authentication (e.g., via Facebook)</li>
-            <li>Display your profile and connect you with nearby users</li>
-            <li>Improve app functionality and user safety</li>
-        </ul>
-
-        <h2>How We Share Your Information</h2>
-        <ul>
-            <li>We do NOT sell or share your information with third parties except as needed for the app’s functionality (e.g., Firebase, Google, Facebook for authentication).</li>
-            <li>Your name, photo, and location may be shown to other McHub users as part of nearby or community features, only with your consent.</li>
-        </ul>
-
-        <h2>Data Security</h2>
-        <p>We store your data securely using industry-standard methods and reputable providers (e.g., Google Firebase). We strive to protect your data, but no method of electronic storage is 100% secure.</p>
-
-        <h2>Your Choices</h2>
-        <ul>
-            <li>You may control what information you share in your profile.</li>
-            <li>You may disable location access at any time via your device settings, though some features may not be available without it.</li>
-        </ul>
-
-        <h2>Contact Us</h2>
-        <p>If you have any questions about this Privacy Policy or your data, please contact us at: <a href="mailto:support@mymchub.com">support@mymchub.com</a></p>
-
-        <h2>Changes to This Policy</h2>
-        <p>We may update this Privacy Policy from time to time. Changes will be posted within the app or on this page.</p>
-
-        <p><strong>Last updated:</strong> 20 July 2025</p>
-    </div>
-</body>
-</html>
+<!-- footer -->
+<div class="footer"><div class="container">
+    <p class="muted">© <span id="y"></span> McHub. All rights reserved.</p>
+    <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
+</div></div>
+<script src="/assets/js/site.js"></script>
+</body></html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,21 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>User Policy – McHub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<div class="nav"><div class="container"><a class="brand" href="/">McHub</a><nav>
+    <a href="/" data-path="/">Home</a><a href="/about.html" data-path="/about.html">About</a>
+    <a href="/store.html" data-path="/store.html">App Store</a>
+    <a href="/privacy.html" data-path="/privacy.html">User Policy</a>
+    <a href="/delete/" data-path="/delete">Delete Account</a>
+</nav></div></div>
+
+<main class="container">
+    <h1>User Policy</h1>
+    <p>…paste your policy here…</p>
+</main>
+
+<div class="footer"><div class="container"><p class="muted">© <span id="y"></span> McHub.</p>
+    <script>document.getElementById('y').textContent=new Date().getFullYear();</script></div></div>
+<script src="/assets/js/site.js"></script>
+</body></html>

--- a/store.html
+++ b/store.html
@@ -1,0 +1,24 @@
+<!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Get the App – McHub</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head><body>
+<div class="nav"><div class="container"><a class="brand" href="/">McHub</a><nav>
+    <a href="/" data-path="/">Home</a><a href="/about.html" data-path="/about.html">About</a>
+    <a href="/store.html" data-path="/store.html">App Store</a>
+    <a href="/privacy.html" data-path="/privacy.html">User Policy</a>
+    <a href="/delete/" data-path="/delete">Delete Account</a>
+</nav></div></div>
+
+<main class="container">
+    <h1>Get the App</h1>
+    <ul>
+        <li><strong>Android:</strong> (Play Store link soon)</li>
+        <li><strong>iOS:</strong> (TestFlight/App Store link soon)</li>
+    </ul>
+</main>
+
+<div class="footer"><div class="container"><p class="muted">© <span id="y"></span> McHub.</p>
+    <script>document.getElementById('y').textContent=new Date().getFullYear();</script></div></div>
+<script src="/assets/js/site.js"></script>
+</body></html>


### PR DESCRIPTION
### What
- Add base pages: index, about, privacy, store, 404
- Add shared header/footer + styles (assets/css/site.css)
- Add delete page (Phase 1) UI at /delete/ 
  - Frontend posts to Cloud Function endpoint placeholder
- Add basic nav + active state + JS helpers

### Notes
- Web delete form will show an error until the Cloud Function 
  `webDeleteRequest` is deployed.
- Pages config: Deploy from main / root (unchanged).

### Test
- / (home) renders
- /about.html
- /privacy.html
- /store.html
- /delete/  (form renders)
- 404 works for unknown routes
